### PR TITLE
fix(aws-s3): hotfix for AWS S3 endpoint

### DIFF
--- a/src/types/ServerOptions.ts
+++ b/src/types/ServerOptions.ts
@@ -65,5 +65,7 @@ export interface ServerOptions {
     access_key_id: string | null;
     secret_key: string | null;
     defaultBucketName: string | null;
+    endpoint: string | null;
+    forcePathStyle: string | null;
   };
 }


### PR DESCRIPTION
src/util/functions.ts:168:37 - error TS2339: Property 'endpoint' does not exist on type '{ region: string; access_key_id: string; secret_key: string; defaultBucketName: string; }'.

168           endpoint: config?.aws_s3?.endpoint || undefined,