### PR TITLE
fix(aws-s3):  "sharp" module using the linuxmusl-x64 runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,9 @@ RUN yarn build
 FROM base
 WORKDIR /usr/src/wpp-server/
 RUN apk add --no-cache chromium
-RUN yarn cache clean
+RUN yarn add @babel/runtime && \
+    yarn add sharp mongoose prom-client --ignore-engines && \
+    yarn cache clean
 COPY . .
 COPY --from=build /usr/src/wpp-server/ /usr/src/wpp-server/
 EXPOSE 21465


### PR DESCRIPTION
/usr/src/wpp-server # node ./dist/server.js
/usr/src/wpp-server/node_modules/sharp/lib/sharp.js:107
  throw new Error(help.join('\n'));
  ^

Error: Could not load the "sharp" module using the linuxmusl-x64 runtime Possible solutions:
- Ensure optional dependencies can be installed: npm install --include=optional sharp yarn add sharp --ignore-engines
- Ensure your package manager supports multi-platform installation: See https://sharp.pixelplumbing.com/install#cross-platform
- Add platform-specific dependencies: npm install --os=linuxmusl --cpu=x64 sharp npm install --force @img/sharp-linuxmusl-x64
- Consult the installation documentation: See https://sharp.pixelplumbing.com/install at Object.<anonymous> (/usr/src/wpp-server/node_modules/sharp/lib/sharp.js:107:9) at Module._compile (node:internal/modules/cjs/loader:1376:14) at Module._extensions..js (node:internal/modules/cjs/loader:1435:10) at Module.load (node:internal/modules/cjs/loader:1207:32) at Module._load (node:internal/modules/cjs/loader:1023:12) at Module.require (node:internal/modules/cjs/loader:1235:19) at require (node:internal/modules/helpers:176:18) at Object.<anonymous> (/usr/src/wpp-server/node_modules/sharp/lib/constructor.js:10:1) at Module._compile (node:internal/modules/cjs/loader:1376:14) at Module._extensions..js (node:internal/modules/cjs/loader:1435:10)



npm notice 
/usr/src/wpp-server # node ./dist/server.js
node:internal/modules/cjs/loader:1147
  throw err; ^

Error: Cannot find module '@babel/runtime/helpers/interopRequireDefault' Require stack:
- /usr/src/wpp-server/dist/server.js at Module._resolveFilename (node:internal/modules/cjs/loader:1144:15) at Module._load (node:internal/modules/cjs/loader:985:27) at Module.require (node:internal/modules/cjs/loader:1235:19) at require (node:internal/modules/helpers:176:18) at Object.<anonymous> (/usr/src/wpp-server/dist/server.js:3:30) at Module._compile (node:internal/modules/cjs/loader:1376:14) at Module._extensions..js (node:internal/modules/cjs/loader:1435:10) at Module.load (node:internal/modules/cjs/loader:1207:32) at Module._load (node:internal/modules/cjs/loader:1023:12) at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:135:12) { code: 'MODULE_NOT_FOUND', requireStack: [ '/usr/src/wpp-server/dist/server.js' ] }